### PR TITLE
Add redirection for old blog links

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,4 +3,14 @@ const withNextra = require('nextra')({
   themeConfig: './theme.config.tsx',
 });
 
-module.exports = withNextra({});
+module.exports = withNextra({
+  async redirects() {
+    return [
+      {
+        source: '/:year/:month/:day/:slug',
+        destination: '/blog/:year/:year-:month-:day-:slug',
+        permanent: true,
+      },
+    ]
+  },
+});

--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ module.exports = withNextra({
   async redirects() {
     return [
       {
-        source: '/:year/:month/:day/:slug',
+        source: '/:year(\\d{4})/:month(\\d{2})/:day(\\d{2})/:slug*',
         destination: '/blog/:year/:year-:month-:day-:slug',
         permanent: true,
       },


### PR DESCRIPTION
Redirect blog links:

- From: `https://www.tuliren.dev/2019/04/06/reading-scarcity`
- To: `https://www.tuliren.dev/blog/2019/2019-04-06-reading-scarcity`